### PR TITLE
fix the minimum startup window

### DIFF
--- a/Ui/App.xaml.cs
+++ b/Ui/App.xaml.cs
@@ -54,6 +54,11 @@ namespace Ui
             Directory.SetCurrentDirectory(AppDomain.CurrentDomain.BaseDirectory); // in case user start app in a different working dictionary.
             ResourceDictionary = this.Resources;
             base.OnStartup(e);
+
+            if (IoC.Get<ConfigurationService>().General.AppStartMinimized == true)
+            {
+                IoC.Get<MainWindowView>().ShowInTaskbar = false;
+            }
         }
 
         public static void Close(int exitCode = 0)

--- a/Ui/View/MainWindowView.xaml.cs
+++ b/Ui/View/MainWindowView.xaml.cs
@@ -67,7 +67,6 @@ namespace PRM.View
             {
                 this.Visibility = Visibility.Collapsed;
                 this.WindowState = WindowState.Minimized;
-                this.ShowInTaskbar = false;
             }
 
             BtnClose.Click += (sender, args) =>


### PR DESCRIPTION
这么改貌似就没问题。应该是启动之后隐藏了任务栏，最小化找不到任务栏所以左下角显示了。

现在这样如果电脑卡了的话，会出现任务栏显示一下然后立马不见。

可以试试效果，如果不行就算了 -_-#